### PR TITLE
Initial implementation of Promises

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ jupyter==1.0.0
 numpy==1.11.1
 rasterio==0.36.0
 requests==2.11.1
+promise==0.4.2


### PR DESCRIPTION
Addresses #6 

Functionally this is equivalent to the usage of `ReplyCallback` with 2 exceptions:
1) All promises are maintained for the lifetime of the kernel
This is necessary because this implementation allows for calling `then` on already resolved promises (this is new).
2) ~~There is a potential race condition in `_make_promise` if the `IOLoop` decides to process an incoming fulfillment before the promise is registered in `self._promises` - this can/should be easily worked around by rearranging the logic of `transport`.~~