### PR TITLE
Initialize html elements before initializing GeoJs map

### DIFF
--- a/geonotebook/__init__.py
+++ b/geonotebook/__init__.py
@@ -1,3 +1,7 @@
+import os
+import sys
+from jinja2 import ChoiceLoader, FileSystemLoader, PrefixLoader
+
 def _jupyter_server_extension_paths():
     return [{
         "module": "geonotebook"
@@ -15,8 +19,26 @@ def _jupyter_nbextension_paths():
 
 
 def load_jupyter_server_extension(nbapp):
-#    import pudb; pu.db
     nbapp.log.info("geonotebook module enabled!")
+
+    """
+    This is out right confusing, but is necessary to meet the following criteria:
+    - Templates in geonotebook/templates will override those in core notebook templates
+    - Core notebook templates can still be referred to/extended by referring to them as core@template.html
+
+    The ChoiceLoader tries each of the loaders in turn until one of them provides the right template.
+    The PrefixLoader allows us to refer to core templates using the core@ prefix, this is necessary
+    because we want to extend templates of the same name while referring to templates in a different loader (core).
+    The PackageLoader lets us put our templates ahead in priority of the notebooks templates.
+    The core_loader is last which falls back to the original loader the notebook uses.
+
+    This implementation is weird, but should be compatible/composable with other notebook extensions
+    and fairly future proof.
+    """
+    nbapp.web_app.settings['jinja2_env'].loader = ChoiceLoader([
+        PrefixLoader({'core': nbapp.web_app.settings['jinja2_env'].loader}, delimiter='@'),
+        FileSystemLoader(os.path.join(os.path.dirname(sys.modules[__name__].__file__), 'templates')),
+        nbapp.web_app.settings['jinja2_env'].loader])
 
 ### Note:  How to add custom web handlers
 #     webapp = nbapp.web_app

--- a/geonotebook/__init__.py
+++ b/geonotebook/__init__.py
@@ -16,13 +16,10 @@ def _jupyter_nbextension_paths():
         # _also_ in the `nbextension/` namespace
         require="geonotebook/index")]
 
+def get_notebook_jinja2_loader(nbapp):
+    """Return the appropriate jinja2 template loader for the notebook app.
 
-
-def load_jupyter_server_extension(nbapp):
-    nbapp.log.info("geonotebook module enabled!")
-
-    """
-    This is out right confusing, but is necessary to meet the following criteria:
+    This is confusing but necessary to meet the following criteria:
     - Templates in geonotebook/templates will override those in core notebook templates
     - Core notebook templates can still be referred to/extended by referring to them as core@template.html
 
@@ -34,11 +31,19 @@ def load_jupyter_server_extension(nbapp):
 
     This implementation is weird, but should be compatible/composable with other notebook extensions
     and fairly future proof.
+
+    :param nbapp: NotebookApp instance
+    :returns: A jinja2 loader designed to work with our notebook templates
+    :rtype: jinja2.ChoiceLoader
     """
-    nbapp.web_app.settings['jinja2_env'].loader = ChoiceLoader([
+    return ChoiceLoader([
         PrefixLoader({'core': nbapp.web_app.settings['jinja2_env'].loader}, delimiter='@'),
         FileSystemLoader(os.path.join(os.path.dirname(sys.modules[__name__].__file__), 'templates')),
         nbapp.web_app.settings['jinja2_env'].loader])
+
+def load_jupyter_server_extension(nbapp):
+    nbapp.log.info("geonotebook module enabled!")
+    nbapp.web_app.settings['jinja2_env'].loader = get_notebook_jinja2_loader(nbapp)
 
 ### Note:  How to add custom web handlers
 #     webapp = nbapp.web_app

--- a/geonotebook/__init__.py
+++ b/geonotebook/__init__.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from jinja2 import ChoiceLoader, FileSystemLoader, PrefixLoader
+from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
 
 def _jupyter_server_extension_paths():
     return [{
@@ -38,7 +38,7 @@ def get_notebook_jinja2_loader(nbapp):
     """
     return ChoiceLoader([
         PrefixLoader({'core': nbapp.web_app.settings['jinja2_env'].loader}, delimiter='@'),
-        FileSystemLoader(os.path.join(os.path.dirname(sys.modules[__name__].__file__), 'templates')),
+        PackageLoader('geonotebook'),
         nbapp.web_app.settings['jinja2_env'].loader])
 
 def load_jupyter_server_extension(nbapp):

--- a/geonotebook/static/css/styles.css
+++ b/geonotebook/static/css/styles.css
@@ -11,7 +11,7 @@ body {
     width: 95%
 }
 
-#geonotebook_panel {
+#geonotebook-panel {
     padding-top: 20px;
     padding-bottom: 20px;
     float: left;

--- a/geonotebook/static/index.js
+++ b/geonotebook/static/index.js
@@ -168,16 +168,8 @@ define(
             }.bind(this));
         };
 
-
         Geonotebook.prototype.init_html_and_css = function(){
-            $('head').append(
-                $('<link/>')
-                    .attr('href', require.toUrl('./css/styles.css'))
-                    .attr('rel', 'stylesheet')
-                    .attr('type', 'text/css')
-            );
-            $('#ipython-main-app').after('<div id="geonotebook_panel"><div id="geonotebook-map" /></div>');
-
+            $('#ipython-main-app').after('<div id="geonotebook-panel"><div id="geonotebook-map" /></div>');
         };
 
         Geonotebook.prototype.load_ipython_extension = function(){

--- a/geonotebook/static/index.js
+++ b/geonotebook/static/index.js
@@ -182,11 +182,9 @@ define(
 
         Geonotebook.prototype.load_ipython_extension = function(){
             if (Jupyter.kernelselector.current_selection == "geonotebook2") {
+                this.init_html_and_css();
                 this.map = new Map(this);
                 this.register_events(Jupyter, events);
-
-                this.init_html_and_css();
-
 
                 // Expose globablly for debugging purposes
                 Jupyter.map = this.map;

--- a/geonotebook/templates/notebook.html
+++ b/geonotebook/templates/notebook.html
@@ -1,0 +1,6 @@
+{% extends "core@notebook.html" %}
+
+{% block stylesheet %}
+  {{ super() }}
+  <link rel="stylesheet" href="/nbextensions/geonotebook/css/styles.css" type="text/css" />
+{% endblock %}


### PR DESCRIPTION
@kotfic If you spam refresh you should be able to reproduce the bug *sometimes* where the `height` passed to GeoJs is 0 because the element hasn't actually been rendered by the time the map is initialized.