### PR TITLE
Render notebook annotations with same style as GeoJS

### DIFF
--- a/geonotebook/annotations.py
+++ b/geonotebook/annotations.py
@@ -21,6 +21,11 @@ class Annotation(object):
                 'args': self._args,
                 'kwargs': self._kwargs}
 
+    def svg(self, *args, **kwargs):
+        if hasattr(super(Annotation, self), 'svg'):
+            kwargs['fill_color'] = self.style['fillColor']
+            return super(Annotation, self).svg(*args, **kwargs)
+
     def _get_kwargs(self, k):
         def _get_kwargs(self):
             return self._kwargs[k]


### PR DESCRIPTION
Based off #48, so [here is the diff](https://github.com/OpenGeoscience/geonotebook/compare/object-serialization...render-annotations-with-same-style).

This is more of an idea than something that has to be merged (since I flagrantly added a new `BaseGeometry` class just to get it working). I was annoyed by the notebook rendering annotations with different styling than the map, and going forward if styling is going to match for notebook side viz (charts and so on), this might be something to consider.