### PR TITLE
Fix promise callback error handling

### DIFF
--- a/geonotebook/layers.py
+++ b/geonotebook/layers.py
@@ -81,9 +81,12 @@ class AnnotationLayer(GeonotebookLayer):
                 "JSONRPCError (%s): %s" % (error['code'], error['message'])
             )
 
+        def callback_error(exception):
+            self.log.error("Callback Error: %s" % exception[0])
+
         return self._remote.clear_annotations().then(
             _clear_annotations, rpc_error
-        )
+        ).catch(callback_error)
 
     @property
     def points(self):

--- a/notebooks/02_Geoserver.ipynb
+++ b/notebooks/02_Geoserver.ipynb
@@ -247,6 +247,7 @@
    },
    "outputs": [],
    "source": [
+    "M.remove_layer(M.layers[0])\n",
     "M.add_layer(rd[1, 2, 3], interval=(0,1), gamma=0.5)"
    ]
   },
@@ -265,6 +266,7 @@
    },
    "outputs": [],
    "source": [
+    "M.remove_layer(M.layers[0])\n",
     "M.add_layer(rd[1, 2, 3], interval=(0,1), gamma=0.5, opacity=0.75)"
    ]
   },
@@ -315,8 +317,9 @@
    },
    "outputs": [],
    "source": [
-    "cmap = plt.get_cmap('winter', 10)\n",
+    "M.remove_layer(M.layers[0])\n",
     "\n",
+    "cmap = plt.get_cmap('winter', 10)\n",
     "M.add_layer(rd[4], colormap=cmap, opacity=0.8)"
    ]
   },
@@ -336,6 +339,8 @@
    "outputs": [],
    "source": [
     "from matplotlib.colors import LinearSegmentedColormap\n",
+    "\n",
+    "M.remove_layer(M.layers[0])\n",
     "\n",
     "# Divergent Blue to Beige to Green colormap\n",
     "cmap =LinearSegmentedColormap.from_list(\n",

--- a/notebooks/03_Time Series.ipynb
+++ b/notebooks/03_Time Series.ipynb
@@ -216,7 +216,7 @@
    },
    "outputs": [],
    "source": [
-    "M.remove_layer(\"NBAR\")"
+    "M.remove_layer(\"NBAR_NDVI\")"
    ]
   },
   {


### PR DESCRIPTION
While working on #48 I found various errors that weren't being visibly thrown inside of the example notebooks which led to a mismatch in state between the client and server. In our promise implementation we need to catch any exceptions that get thrown in the callbacks of our original promise.

This fixes the issues with the notebooks and in the future exceptions will actually be propagated to the logger. To test this just run notebook 2 or 3 from 6a5e152 (before I fixed them) to watch the exceptions being logged.

The tl;dr:
```
# Won't catch errors thrown in some_callback, everything will appear to be fine
remote.set_center(x, y, z).then(some_callback)

# some_handler will be notified of errors that occur in some_callback
remote.set_center(x, y, z).then(some_callback).catch(some_handler)
``` 