### PR TITLE
Add utilities for sending/receiving logs from external applications

### DIFF
--- a/geonotebook/__init__.py
+++ b/geonotebook/__init__.py
@@ -1,4 +1,7 @@
 from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
+from notebook.utils import url_path_join
+
+import pkg_resources
 
 
 def _jupyter_server_extension_paths():
@@ -58,18 +61,10 @@ def load_jupyter_server_extension(nbapp):
     nbapp.web_app.settings['jinja2_env'].loader = \
         get_notebook_jinja2_loader(nbapp)
 
-# Note:  How to add custom web handlers
-#     webapp = nbapp.web_app
-#     base_url = webapp.settings['base_url']
-#
-#     webapp.add_handlers(".*$", [
-#         (ujoin(base_url, r"/nbextensions"), NBExtensionHandler),
-#         (ujoin(base_url, r"/nbextensions/"), NBExtensionHandler),
-#         (ujoin(base_url, r"/nbextensions/config/rendermd/(.*)"),
-#          RenderExtensionHandler),
-#     ])
+    webapp = nbapp.web_app
+    base_url = webapp.settings['base_url']
 
-#   Note: Ugly hack to add geonotebook template to jinja2 search path
-#     nbapp.web_app.settings['jinja2_env'].loader.searchpath = \
-#        [u"/home/kotfic/src/jupyter/geonotebook/geonotebook/templates"] + \
-#        nbapp.web_app.settings['jinja2_env'].loader.searchpath
+    for ep in pkg_resources.iter_entry_points(
+            group='geonotebook.handlers.default'):
+        webapp.add_handlers('.*$', [(url_path_join(base_url, ep.name),
+                                     ep.load())])

--- a/geonotebook/logging_utils.py
+++ b/geonotebook/logging_utils.py
@@ -1,0 +1,36 @@
+import logging
+import logging.handlers
+
+from notebook.base.handlers import IPythonHandler
+import requests
+
+
+class LoggingRequestHandler(IPythonHandler):
+    """Handles incoming requests to the /log endpoint of the notebook."""
+
+    def check_xsrf_cookie(self):
+        return True
+
+    def post(self):
+        self.log.handle(logging.makeLogRecord(self.get_json_body()))
+
+
+class JsonHTTPHandler(logging.handlers.HTTPHandler):
+    """Handles sending logs over HTTP in a JSON format.
+
+    Example Usage:
+    >>> import logging
+    >>> logger = logging.getLogger('example_log')
+    >>> logger.addHandler(JsonHTTPHandler('http://localhost:8888', '/log'))
+    >>> logger.info('Informational logging message')
+    """
+
+    def __init__(self, host, url):
+        return super(JsonHTTPHandler, self).__init__(host, url, 'POST')
+
+    def emit(self, record):
+        try:
+            record = self.mapLogRecord(record)
+            requests.post(self.host + self.url, json=record)
+        except Exception:
+            self.handleError(record)

--- a/setup.py
+++ b/setup.py
@@ -278,7 +278,9 @@ setup(
             'geotiff = geonotebook.wrappers.image:GeoTiffImage',
             'tiff = geonotebook.wrappers.image:GeoTiffImage',
             'tif = geonotebook.wrappers.image:GeoTiffImage'
+        ],
+        'geonotebook.handlers.default': [
+            '/log = geonotebook.logging_utils:LoggingRequestHandler'
         ]
-
     }
 )


### PR DESCRIPTION
This will allow any application that can talk to the notebook over HTTP
to POST log records as JSON to the /log endpoint and have them be processed and
logged within the notebook application.

It also adds the "client" logging handler which can talk to this
endpoint. JsonHTTPHandler is a slight modification of the HTTPHandler,
due to the fact that we would rather use JSON as the messaging medium
rather than url encoded messages in order to avoid casting values as
integers, floats, etc.