### PR TITLE
Fix Geonotebook role and add KTile role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 htmlcov/
 *.lprof
 /.dir-locals.el
+/.vagrant

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ tox
 ## Docker Container
 System requirements for running the notebook can sometimes prove burdensome to install. To ease these issues we have included a [docker container](devops/docker) that will run the notebook inside a containerized process. 
 
+## Vagrant Machine
+Additionally there is a `Vagrantfile` for standing up an instance of Geonotebook within a virtual machine, further instructions can be found [here](Vagrant.md).
 
 ## Tile Server
 

--- a/Vagrant.md
+++ b/Vagrant.md
@@ -1,0 +1,35 @@
+Vagrant provisioning for Geonotebook
+==================================
+
+Running
+-------
+From the root of the directory, running `vagrant up` will result in a running virtual machine with a message like this one:
+```
+Geonotebook is running at http://localhost:8888
+```
+
+
+Configurable Options
+--------------------
+Through the use of Ansible extra_vars, any of the variables documented in the [Geonotebook role docs](devops/roles/geonotebook) can be manipulated.
+
+
+Environment Variables
+---------------------
+| variable                 | comments                                                                    |
+| ------------------------ | --------------------------------------------------------------------------- |
+| VAGRANT_MEMORY           | The number (in MB) of RAM to use on the virtual machine (defaults to 2048). |
+| VAGRANT_CPUS             | The number of CPUs to use on the virtual machine (defaults to 2).           |
+| GEONOTEBOOK_DIR          | Documentation for this can be found in the [Geonotebook role docs](devops/roles/geonotebook).       |
+| GEONOTEBOOK_VERSION      | Documentation for this can be found in the [Geonotebook role docs](devops/roles/geonotebook).       |
+| GEONOTEBOOK_UPDATE       | Documentation for this can be found in the [Geonotebook role docs](devops/roles/geonotebook).       |
+| GEONOTEBOOK_FORCE        | Documentation for this can be found in the [Geonotebook role docs](devops/roles/geonotebook).       |
+| GEONOTEBOOK_AUTH_ENABLED | Documentation for this can be found in the [Geonotebook role docs](devops/roles/geonotebook).       |
+| GEONOTEBOOK_AUTH_TOKEN   | Documentation for this can be found in the [Geonotebook role docs](devops/roles/geonotebook).       |
+
+
+Jupyter Auth
+------------
+By default, Jupyter authentication is disabled in the Vagrant environment as it's meant to be a development environment. Jupyter authentication should always be enabled on production systems.
+
+If Jupyter authentication is desired, the environment variables related to `GEONOTEBOOK_AUTH_*` must be set, note the auth token must be set to the same token each time the machine is provisioned.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,8 @@ Vagrant.configure("2") do |config|
     ansible.galaxy_role_file = "devops/site-dev-requirements.yml"
 
     ansible.extra_vars = {
-      geonotebook_auth_enabled: false
+      geonotebook_auth_enabled: false,
+      geonotebook_version: ENV["GEONOTEBOOK_VERSION"] || "master"
     }
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,6 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "bento/ubuntu-16.04"
 
-
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box
     config.cache.enable :apt
@@ -14,12 +13,15 @@ Vagrant.configure("2") do |config|
   config.vm.hostname = "geonotebook"
   config.vm.network "forwarded_port", guest: 8888, host: 8888
   config.vm.post_up_message = "Geonotebook is running at http://localhost:8888"
-
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/opt/geonotebook"
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "devops/site-dev.yml"
     ansible.galaxy_role_file = "devops/site-dev-requirements.yml"
+
+    ansible.extra_vars = {
+      geonotebook_auth_enabled: false
+    }
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,7 @@ Vagrant.configure("2") do |config|
     config.cache.enable :npm
   end
 
+  config.vm.define :geonotebook
   config.vm.hostname = "geonotebook"
   config.vm.network "forwarded_port", guest: 8888, host: 8888
   config.vm.post_up_message = "Geonotebook is running at http://localhost:8888"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,25 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-16.04"
+
+
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.scope = :box
+    config.cache.enable :apt
+    config.cache.enable :npm
+  end
+
+  config.vm.hostname = "geonotebook"
+  config.vm.network "forwarded_port", guest: 8888, host: 8888
+  config.vm.post_up_message = "Geonotebook is running at http://localhost:8888"
+
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder ".", "/opt/geonotebook"
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "devops/site-dev.yml"
+    ansible.galaxy_role_file = "devops/site-dev-requirements.yml"
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,9 +25,15 @@ Vagrant.configure("2") do |config|
     ansible.playbook = "devops/site-dev.yml"
     ansible.galaxy_role_file = "devops/site-dev-requirements.yml"
 
+    # TODO: This should be replaced with some general solution
+    # which passes through GEONOTEBOOK_* env variables.
     ansible.extra_vars = {
-      geonotebook_auth_enabled: false,
-      geonotebook_version: ENV["GEONOTEBOOK_VERSION"] || "master"
+      geonotebook_dir: ENV["GEONOTEBOOK_DIR"] || "/opt/geonotebook",
+      geonotebook_version: ENV["GEONOTEBOOK_VERSION"] || "master",
+      geonotebook_update: ENV["GEONOTEBOOK_UPDATE"] || false,
+      geonotebook_force: ENV["GEONOTEBOOK_FORCE"] || false,
+      geonotebook_auth_enabled: ENV["GEONOTEBOOK_AUTH_ENABLED"] || false,
+      geonotebook_auth_token: ENV["GEONOTEBOOK_AUTH_TOKEN"] || ""
     }
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,11 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/opt/geonotebook"
 
+  config.vm.provider "virtualbox" do |virtualbox|
+    virtualbox.memory = ENV["VAGRANT_MEMORY"] || 2048
+    virtualbox.customize ["modifyvm", :id, "--cpus", ENV["VAGRANT_CPUS"] || 2]
+  end
+
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "devops/site-dev.yml"
     ansible.galaxy_role_file = "devops/site-dev-requirements.yml"

--- a/devops/roles/.gitignore
+++ b/devops/roles/.gitignore
@@ -1,0 +1,5 @@
+/*
+!ec2/
+!geonotebook/
+!jupyterhub/
+!ktile/

--- a/devops/roles/geonotebook/README.md
+++ b/devops/roles/geonotebook/README.md
@@ -1,0 +1,21 @@
+geonotebook
+===========
+
+An Ansible role to install [Geonotebook](https://github.com/opengeoscience/geonotebook).
+
+Requirements
+------------
+
+This is intended to be run on a clean Ubuntu 16.04 system.
+
+Role Variables
+--------------
+
+| parameter                | required | default          | comments                                                                                                                        |
+| ------------------------ | -------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| geonotebook_dir          | no       | /opt/geonotebook | Path to download and build Geonotebook in.                                                                                      |
+| geonotebook_version      | no       | master           | Git commit-ish for fetching Geonotebook.                                                                                        |
+| geonotebook_update       | no       | no               | Whether provisioning should fetch new versions via git.                                                                         |
+| geonotebook_force        | no       | no               | Whether provisioning should discard modified files in the working directory.                                                    |
+| geonotebook_auth_enabled | no       | yes              | Whether or not Jupyter token based authentication should be enabled.                                                            |
+| geonotebook_auth_token   | no       |                  | A token to use for Jupyter token based authentication. If this is blank, it is equivalent to geonotebook_auth_enabled being no. |

--- a/devops/roles/geonotebook/defaults/main.yml
+++ b/devops/roles/geonotebook/defaults/main.yml
@@ -2,3 +2,6 @@ geonotebook_version: master
 geonotebook_dir: /opt/geonotebook
 geonotebook_update: no
 geonotebook_force: no
+
+geonotebook_auth_enabled: yes
+geonotebook_auth_token: ""

--- a/devops/roles/geonotebook/defaults/main.yml
+++ b/devops/roles/geonotebook/defaults/main.yml
@@ -1,2 +1,4 @@
 geonotebook_version: master
 geonotebook_dir: /opt/geonotebook
+geonotebook_update: no
+geonotebook_force: no

--- a/devops/roles/geonotebook/tasks/daemon.yml
+++ b/devops/roles/geonotebook/tasks/daemon.yml
@@ -1,0 +1,14 @@
+---
+- name: Install service
+  template:
+    src: "geonotebook.service.j2"
+    dest: "/etc/systemd/system/geonotebook.service"
+  become: yes
+  become_user: root
+
+- name: (Re)start service
+  service:
+    name: geonotebook
+    state: restarted
+  become: yes
+  become_user: root

--- a/devops/roles/geonotebook/tasks/main.yml
+++ b/devops/roles/geonotebook/tasks/main.yml
@@ -1,4 +1,25 @@
 ---
+- name: Install system dependencies
+  apt:
+    name: "{{ item }}"
+  with_items:
+    - git
+    - curl
+    - awscli
+    - gdal-bin
+    - python-numpy
+    - python-matplotlib
+    - libgdal-dev
+    - python-numpy
+    - python-matplotlib
+    - python-gdal
+    - python-matplotlib
+    - python-numpy
+    - python-pip
+    - python-rasterio
+    - python-requests
+  become: yes
+
 - name: Ensure geonotebook base directory exists
   file:
     path: "{{ geonotebook_dir }}"
@@ -23,26 +44,6 @@
     repo: "ppa:ubuntugis/ppa"
     state: present
     update_cache: yes
-  become: yes
-
-- name: Install system dependencies
-  apt:
-    name: "{{ item }}"
-  with_items:
-    - curl
-    - awscli
-    - gdal-bin
-    - python-numpy
-    - python-matplotlib
-    - libgdal-dev
-    - python-numpy
-    - python-matplotlib
-    - python-gdal
-    - python-matplotlib
-    - python-numpy
-    - python-pip
-    - python-rasterio
-    - python-requests
   become: yes
 
 - name: Update pip and install example notebook requirements

--- a/devops/roles/geonotebook/tasks/main.yml
+++ b/devops/roles/geonotebook/tasks/main.yml
@@ -29,6 +29,8 @@
   apt:
     name: "{{ item }}"
   with_items:
+    - curl
+    - awscli
     - gdal-bin
     - python-numpy
     - python-matplotlib

--- a/devops/roles/geonotebook/tasks/main.yml
+++ b/devops/roles/geonotebook/tasks/main.yml
@@ -22,30 +22,13 @@
     - python-pip
     - python-rasterio
     - python-requests
-    - python3-gdal
-    - python3-matplotlib
-    - python3-numpy
-    - python3-pip
-    - python3-rasterio
-    - python3-requests
 
 - name: Update pip and install example notebook requirements
   pip:
     executable: pip2
-    name: "{{ item }}"
+    name: "pip"
     state: latest
     chdir: "{{ geonotebook_dir }}"
-  with_items:
-    - pip
-
-- name: Update pip3 and install example notebook requirements
-  pip:
-    executable: pip3
-    name: "{{ item }}"
-    state: latest
-    chdir: "{{ geonotebook_dir }}"
-  with_items:
-    - pip
 
 - name: Use system installed python-gdal
   lineinfile:
@@ -54,24 +37,21 @@
     dest: "{{geonotebook_dir}}/requirements.txt"
   when: use_system_python_gdal is defined
 
-
 - name: Install geonotebook python requirements
   pip:
-    executable: "{{ item }}"
+    executable: pip2
     requirements: "{{geonotebook_dir}}/requirements.txt"
-  with_items:
-    - pip2
-    - pip3
+  environment:
+    CPLUS_INCLUDE_PATH: /usr/include/gdal
+    C_INCLUDE_PATH: /usr/include/gdal
 
 - name: Install the geonotebook package
   pip:
-    executable: "{{ item }}"
+    executable: pip2
+    extra_args: "-e"
     name: "."
     state: latest
     chdir: "{{ geonotebook_dir }}"
-  with_items:
-    - pip2
-    - pip3
 
 - name: Template out the geonotebook.ini configuration file
   template:

--- a/devops/roles/geonotebook/tasks/main.yml
+++ b/devops/roles/geonotebook/tasks/main.yml
@@ -107,3 +107,5 @@
     line: "c.NotebookApp.token = '{{ geonotebook_auth_token }}'"
     state: present
   when: geonotebook_auth_enabled
+
+- include: daemon.yml

--- a/devops/roles/geonotebook/tasks/main.yml
+++ b/devops/roles/geonotebook/tasks/main.yml
@@ -22,10 +22,8 @@
   apt_repository:
     repo: "ppa:ubuntugis/ppa"
     state: present
-
-- name: update apt cache
-  apt:
     update_cache: yes
+  become: yes
 
 - name: Install system dependencies
   apt:
@@ -43,6 +41,7 @@
     - python-pip
     - python-rasterio
     - python-requests
+  become: yes
 
 - name: Update pip and install example notebook requirements
   pip:
@@ -50,6 +49,7 @@
     name: "pip"
     state: latest
     chdir: "{{ geonotebook_dir }}"
+  become: yes
 
 - name: Use system installed python-gdal
   lineinfile:
@@ -65,6 +65,7 @@
   environment:
     CPLUS_INCLUDE_PATH: /usr/include/gdal
     C_INCLUDE_PATH: /usr/include/gdal
+  become: yes
 
 - name: Install the geonotebook package
   pip:
@@ -73,11 +74,13 @@
     name: "."
     state: latest
     chdir: "{{ geonotebook_dir }}"
+  become: yes
 
 - name: Template out the geonotebook.ini configuration file
   template:
     src: geonotebook.ini.j2
     dest: /usr/local/etc/geonotebook.ini
+  become: yes
 
 - name: Generate jupyter notebook config
   command: "jupyter notebook --generate-config"

--- a/devops/roles/geonotebook/tasks/main.yml
+++ b/devops/roles/geonotebook/tasks/main.yml
@@ -78,3 +78,32 @@
   template:
     src: geonotebook.ini.j2
     dest: /usr/local/etc/geonotebook.ini
+
+- name: Generate jupyter notebook config
+  command: "jupyter notebook --generate-config"
+  args:
+    creates: "{{ ansible_user_dir }}/.jupyter/jupyter_notebook_config.py"
+
+- debug:
+    msg: "Specify geonotebook_auth_token when deploying to a production environment"
+  when: geonotebook_auth_token == ""
+
+- name: Remove existing auth token setting
+  lineinfile:
+    name: "{{ ansible_user_dir }}/.jupyter/jupyter_notebook_config.py"
+    regexp: "^c.NotebookApp.token"
+    state: absent
+
+- name: Disable auth token
+  lineinfile:
+    name: "{{ ansible_user_dir }}/.jupyter/jupyter_notebook_config.py"
+    line: "c.NotebookApp.token = ''"
+    state: present
+  when: not geonotebook_auth_enabled
+
+- name: Configure auth token
+  lineinfile:
+    name: "{{ ansible_user_dir }}/.jupyter/jupyter_notebook_config.py"
+    line: "c.NotebookApp.token = '{{ geonotebook_auth_token }}'"
+    state: present
+  when: geonotebook_auth_enabled

--- a/devops/roles/geonotebook/tasks/main.yml
+++ b/devops/roles/geonotebook/tasks/main.yml
@@ -1,11 +1,22 @@
 ---
+- name: Ensure geonotebook base directory exists
+  file:
+    path: "{{ geonotebook_dir }}"
+    state: directory
+    group: "{{ ansible_user_id }}"
+    owner: "{{ ansible_user_id }}"
+    mode: 0755
+  become: yes
+  become_user: root
+
 - name: Clone the geonotebook repository
   git:
     repo: https://github.com/OpenGeoscience/geonotebook.git
     dest: "{{ geonotebook_dir }}"
     version: "{{ geonotebook_version }}"
     accept_hostkey: yes
-    force: yes
+    update: "{{ geonotebook_update|default(omit) }}"
+    force: "{{ geonotebook_force|default(omit) }}"
 
 - name: add ubuntugis ppa
   apt_repository:

--- a/devops/roles/geonotebook/tasks/main.yml
+++ b/devops/roles/geonotebook/tasks/main.yml
@@ -18,6 +18,8 @@
     - python-pip
     - python-rasterio
     - python-requests
+    - python-seaborn
+    - python-skimage
   become: yes
 
 - name: Ensure geonotebook base directory exists

--- a/devops/roles/geonotebook/tasks/main.yml
+++ b/devops/roles/geonotebook/tasks/main.yml
@@ -5,6 +5,16 @@
     dest: "{{ geonotebook_dir }}"
     version: "{{ geonotebook_version }}"
     accept_hostkey: yes
+    force: yes
+
+- name: add ubuntugis ppa
+  apt_repository:
+    repo: "ppa:ubuntugis/ppa"
+    state: present
+
+- name: update apt cache
+  apt:
+    update_cache: yes
 
 - name: Install system dependencies
   apt:

--- a/devops/roles/geonotebook/templates/geonotebook.ini.j2
+++ b/devops/roles/geonotebook/templates/geonotebook.ini.j2
@@ -5,10 +5,10 @@ log_level = WARNING
 [geoserver]
 username = admin
 password = geoserver
-url = http://{{ inventory_hostname }}:8080/geoserver
+url = {{ geoserver_url | default("http://localhost:8080/geoserver") }}
 
 [ktile]
-url = http://{{ inventory_hostname }}:8888/ktile
+url = {{ ktile_url | default("http://localhost:8888/ktile") }}
 default_cache = ktile_default_cache
 
 [ktile_default_cache]

--- a/devops/roles/geonotebook/templates/geonotebook.ini.j2
+++ b/devops/roles/geonotebook/templates/geonotebook.ini.j2
@@ -1,7 +1,17 @@
 [default]
-vis_server = geoserver
+vis_server = ktile
+log_level = WARNING
 
 [geoserver]
 username = admin
 password = geoserver
 url = http://{{ inventory_hostname }}:8080/geoserver
+
+[ktile]
+url = http://{{ inventory_hostname }}:8888/ktile
+default_cache = ktile_default_cache
+
+[ktile_default_cache]
+name = Test
+path = /tmp/stache
+umask = 0000

--- a/devops/roles/geonotebook/templates/geonotebook.service.j2
+++ b/devops/roles/geonotebook/templates/geonotebook.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Geonotebook
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/jupyter notebook --no-browser --ip=0.0.0.0
+User={{ ansible_user_id }}
+Group={{ ansible_user_id }}
+WorkingDirectory={{ geonotebook_dir }}/notebooks
+
+[Install]
+WantedBy=multi-user.target

--- a/devops/roles/ktile/defaults/main.yml
+++ b/devops/roles/ktile/defaults/main.yml
@@ -1,0 +1,2 @@
+ktile_version: master
+ktile_dir: /opt/ktile

--- a/devops/roles/ktile/defaults/main.yml
+++ b/devops/roles/ktile/defaults/main.yml
@@ -1,2 +1,4 @@
 ktile_version: master
 ktile_dir: /opt/ktile
+ktile_update: no
+ktile_force: no

--- a/devops/roles/ktile/tasks/main.yml
+++ b/devops/roles/ktile/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+- name: Make ktile directory
+  file:
+    path: "{{ ktile_dir }}"
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+  become: yes
+
+- name: Clone the ktile repository
+  git:
+    repo: https://github.com/OpenGeoscience/ktile.git
+    dest: "{{ ktile_dir }}"
+    version: "{{ ktile_version }}"
+    accept_hostkey: yes
+
+- name: add ubuntugis ppa
+  apt_repository:
+    repo: "ppa:ubuntugis/ppa"
+    state: present
+    update_cache: yes
+
+- name: Install system dependencies
+  apt:
+    name: "{{ item }}"
+  with_items:
+    - gdal-bin
+    - python-pip
+    - python-psycopg2
+  become: yes
+
+- name: upgrade pip
+  pip:
+    executable: pip2
+    name: pip
+    state: latest
+  become: yes
+
+- name: Use system installed python-gdal
+  lineinfile:
+    line: "gdal==1.10.0"
+    state: absent
+    dest: "{{ ktile_dir }}/prerequirements.txt"
+  when: true
+
+- name: pip install requirements
+  pip:
+    executable: pip2
+    chdir: "{{ ktile_dir }}"
+    requirements: "{{ item }}"
+  with_items:
+    - "prerequirements.txt"
+    - "requirements-dev.txt"
+    - "requirements.txt"
+  become: yes
+
+- name: pip install ktile
+  pip:
+    executable: pip2
+    chdir: "{{ ktile_dir }}"
+    extra_args: "-e"
+    name: "."
+  become: yes

--- a/devops/roles/ktile/tasks/main.yml
+++ b/devops/roles/ktile/tasks/main.yml
@@ -12,6 +12,8 @@
     repo: https://github.com/OpenGeoscience/ktile.git
     dest: "{{ ktile_dir }}"
     version: "{{ ktile_version }}"
+    update: "{{ ktile_update }}"
+    force: "{{ ktile_force }}"
     accept_hostkey: yes
 
 - name: add ubuntugis ppa

--- a/devops/roles/ktile/tasks/main.yml
+++ b/devops/roles/ktile/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: Install system dependencies
+  apt:
+    name: "{{ item }}"
+  with_items:
+    - git
+    - gdal-bin
+    - python-pip
+    - python-psycopg2
+  become: yes
+
 - name: Make ktile directory
   file:
     path: "{{ ktile_dir }}"
@@ -21,15 +31,6 @@
     repo: "ppa:ubuntugis/ppa"
     state: present
     update_cache: yes
-
-- name: Install system dependencies
-  apt:
-    name: "{{ item }}"
-  with_items:
-    - gdal-bin
-    - python-pip
-    - python-psycopg2
-  become: yes
 
 - name: upgrade pip
   pip:

--- a/devops/site-dev-requirements.yml
+++ b/devops/site-dev-requirements.yml
@@ -1,0 +1,2 @@
+- src: geerlingguy.nodejs
+  version: 4.0.0

--- a/devops/site-dev.yml
+++ b/devops/site-dev.yml
@@ -1,0 +1,11 @@
+- name: Setup dev environment
+  hosts: all
+
+  become: yes
+
+  roles:
+    - role: geerlingguy.nodejs
+    - role: ktile
+    - role: geonotebook
+      geonotebook_version: master
+      use_system_python_gdal: true

--- a/devops/site-dev.yml
+++ b/devops/site-dev.yml
@@ -1,11 +1,11 @@
 - name: Setup dev environment
   hosts: all
 
-  become: yes
-
   roles:
     - role: geerlingguy.nodejs
+      become: yes
     - role: ktile
+      become: yes
     - role: geonotebook
       geonotebook_version: master
       use_system_python_gdal: true


### PR DESCRIPTION
@kotfic Give this a shot.

`vagrant up` should give you what you want. Note this mounts your current directory as the path to the code.

The only annoyance is that in order to figure out the token, you need to ssh into the machine and type `systemctl status geonotebook`. There's a variable that disables tokens altogether, how should we handle the defaults? I can see running the status command and printing the output after provisioning the VM.