### PR TITLE
Don't enable extensions in setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include config/*.ini
+include geonotebook/static/*

--- a/README.md
+++ b/README.md
@@ -38,11 +38,35 @@ pip install -r requirements.txt
 
 pip install .
 
-# Alternatively you may do a development install, e.g.
-# pip install -e .
+# Enable both the notebook and server extensions
+jupyter serverextension enable --user --py geonotebook
+jupyter nbextension enable --user --py geonotebook
 ```
 
-*Note* The geonotebook package has been designed to install the notebook extension etc automatically. You should not need to run ```jupyter nbextension install ...``` etc.
+*Note* The `serverextension` and `nbextension` commands accept flags that configure how
+and where the extensions are installed.  For example, if you only want the extension enabled in the
+current virtual environment, you can replace `--user` with `--sys-prefix`.
+
+### Installing geonotebook for development
+When developing geonotebook, it is often helpful to install packages as a reference to the
+checked out repository rather than copying them to the system `site-packages`.  A "development
+install" will allow you to make live changes to python or javascript without reinstalling the
+package.
+```bash
+# Install the geonotebook python package as "editable"
+pip install -e .
+
+# Install the notebook extension as a symlink
+jupyter nbextension install --sys-prefix --symlink --py geonotebook
+
+# Enable the extension
+jupyter serverextension enable --sys-prefix --py geonotebook
+jupyter nbextension enable --sys-prefix --py geonotebook
+
+# Start the javascript builder
+cd js
+npm run watch
+```
 
 ### Run the notebook:
 ```bash

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ pip install -r requirements.txt
 pip install .
 
 # Enable both the notebook and server extensions
-jupyter serverextension enable --user --py geonotebook
-jupyter nbextension enable --user --py geonotebook
+jupyter serverextension enable --sys-prefix --py geonotebook
+jupyter nbextension enable --sys-prefix --py geonotebook
 ```
 
 *Note* The `serverextension` and `nbextension` commands accept flags that configure how
-and where the extensions are installed.  For example, if you only want the extension enabled in the
-current virtual environment, you can replace `--user` with `--sys-prefix`.
+and where the extensions are installed.  See `jupyter serverextension --help` for more
+information.
 
 ### Installing geonotebook for development
 When developing geonotebook, it is often helpful to install packages as a reference to the

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ dependencies:
     - sudo apt-get install -q -y libgeos-c1v5
     - sudo apt-get install -q -y libgdal20
     - sudo apt-get install -q -y gdal-bin libgdal-dev python3-numpy python-numpy
+    - sudo apt-get install -q -y libzmq3-dev
     - pip install -U pip
     - pip install tox tox-pyenv entrypoints
     - pyenv local 2.7.12 3.5.2

--- a/setup.py
+++ b/setup.py
@@ -215,29 +215,11 @@ def install_geonotebook_ini(cmd, link=False):
                     shutil.copyfile(src, dest)
 
 
-def install_nbextension(cmd, link=False):
-    from notebook.nbextensions import (install_nbextension_python,
-                                       enable_nbextension)
-
-    install_nbextension_python("geonotebook",
-                               overwrite=True, sys_prefix=True, symlink=link)
-    enable_nbextension("notebook", "geonotebook/index", sys_prefix=True)
-
-
-def install_serverextension(cmd):
-    from notebook.serverextensions import toggle_serverextension_python
-    toggle_serverextension_python('geonotebook', enabled=True, sys_prefix=True)
-
-
-@post_install(install_serverextension)
-@post_install(install_nbextension)
 @post_install(install_kernel)
 class CustomInstall(install):
     pass
 
 
-@post_install(install_serverextension)
-@post_install(install_nbextension, link=True)
 @post_install(install_geonotebook_ini, link=True)
 @post_install(install_kernel)
 class CustomDevelop(develop):

--- a/setup.py
+++ b/setup.py
@@ -262,11 +262,13 @@ setup(
     },
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     data_files=[
-        ('etc', ['config/geonotebook.ini'])
+        ('etc', ['config/geonotebook.ini']),
+        ('share/jupyter/nbextensions/geonotebook', [
+            'geonotebook/static/index.js',
+            'geonotebook/static/styles.css'
+        ])
     ],
-    package_data={'geonotebook': ['static/*.js',
-                                  'static/*.css',
-                                  'templates/*.html']},
+    package_data={'geonotebook': ['templates/*.html']},
     entry_points={
         'geonotebook.wrappers.raster': [
             'geotiff = geonotebook.wrappers.image:RasterIOReader',

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install -r requirements.txt
+    jupyter nbextension enable --sys-prefix --py geonotebook
+    jupyter serverextension enable --sys-prefix --py geonotebook
     pytest --cov=geonotebook --cov-config .coveragerc {posargs} tests/
 
 [testenv:flake8]


### PR DESCRIPTION
This is done except for the ansible changes, which will conflict with #82.  It should only involve adding the two commands that enable the extension.  Also note, I changed the recommended install instructions to `--user` not because I think it's better, but because that is what most of the other extensions say.  I think this will minimize the problems caused by the notebook bug. 

Fixes #75 

