### PR TITLE
Enable geonotebook in devops scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,15 +49,16 @@ RUN /usr/sbin/jupyter-notebook --generate-config \
     && sed -i s/#c.NotebookApp.token\ \=\ \'\'/c.NotebookApp.token\ \=\ \'\'/g \
            /root/.jupyter/jupyter_notebook_config.py
 
-RUN git clone https://github.com/OpenGeoscience/geonotebook.git /opt/geonotebook \
-    && pushd /opt/geonotebook \
-    && git checkout devops_enable_extension \
-    && pip2 install https://github.com/OpenGeoscience/KTile/archive/master.zip \
+RUN pip2 install https://github.com/OpenGeoscience/KTile/archive/master.zip
+
+ADD . /opt/geonotebook
+ADD devops/docker/jupyter.sh /jupyter.sh
+
+RUN pushd /opt/geonotebook \
     && pip2 install . \
     && jupyter serverextension enable --py geonotebook --sys-prefix \
     && jupyter nbextension enable --py geonotebook --sys-prefix
 
 VOLUME /notebooks
 WORKDIR /notebooks
-ADD jupyter.sh /jupyter.sh
 CMD ../jupyter.sh

--- a/devops/docker/Dockerfile
+++ b/devops/docker/Dockerfile
@@ -51,9 +51,11 @@ RUN /usr/sbin/jupyter-notebook --generate-config \
 
 RUN git clone https://github.com/OpenGeoscience/geonotebook.git /opt/geonotebook \
     && pushd /opt/geonotebook \
-    && git checkout master \
+    && git checkout devops_enable_extension \
     && pip2 install https://github.com/OpenGeoscience/KTile/archive/master.zip \
-    && pip2 install .
+    && pip2 install . \
+    && jupyter serverextension enable --py geonotebook --sys-prefix \
+    && jupyter nbextension enable --py geonotebook --sys-prefix
 
 VOLUME /notebooks
 WORKDIR /notebooks

--- a/devops/docker/README.md
+++ b/devops/docker/README.md
@@ -3,7 +3,7 @@
 Geonotebook relies on a complex stack of technologies that are not always easy to install and properly configure. To ease this complexity we provide a docker container for running the notebook on docker compatible systems. To install docker on your system please see docker's [documentation](https://docs.docker.com/engine/installation/) for your operating system.
 
 ## Build the container
-First you must build the docker container.  After checking out the current repository and navigating to ```devops/docker/``` you can run
+First you must build the docker container.  After checking out the current repository, you can run
 
 ```
 docker build -t geonotebook .

--- a/devops/roles/geonotebook/tasks/main.yml
+++ b/devops/roles/geonotebook/tasks/main.yml
@@ -116,4 +116,14 @@
     state: present
   when: geonotebook_auth_enabled
 
+- name: Enable geonotebook server extension
+  command: "jupyter serverextension enable --user --py geonotebook"
+  args:
+    creates: "{{ ansible_user_dir }}/.jupyter/jupyter_notebook_config.json"
+
+- name: Enable geonotebook notebook extension
+  command: "jupyter nbextension enable --user --py geonotebook"
+  args:
+    creates: "{{ ansible_user_dir }}/.jupyter/nbconfig/notebook.json"
+
 - include: daemon.yml


### PR DESCRIPTION
As discussed with @kotfic, this also moves the `Dockerfile` to the repository root and uses the current directory's content rather than cloning from github.  I rearranged the commands so that rebuilding should be pretty fast when switching branches because the `ADD` is done as late as possible.  All containers produced before then will be cached.