### PR TITLE
Basic vector data subsetting

### DIFF
--- a/geonotebook/annotations.py
+++ b/geonotebook/annotations.py
@@ -9,6 +9,10 @@ class Annotation(object):
         self.layer = kwargs.pop('layer', None)
         self._args = args
         self._kwargs = kwargs
+
+        # set the default fill if not provided in the constructor
+        self.rgb = '#b0de5c'
+
         for k, v in kwargs.items():
             setattr(Annotation, k, property(self._get_kwargs(k),
                                             self._set_kwargs(k),

--- a/geonotebook/annotations.py
+++ b/geonotebook/annotations.py
@@ -11,7 +11,7 @@ class Annotation(object):
         self._kwargs = kwargs
 
         # set the default fill if not provided in the constructor
-        self.rgb = '#b0de5c'
+        self.rgb = kwargs.get('rgb', '#b0de5c')
 
         for k, v in kwargs.items():
             setattr(Annotation, k, property(self._get_kwargs(k),

--- a/geonotebook/kernel.py
+++ b/geonotebook/kernel.py
@@ -388,7 +388,7 @@ class Geonotebook(object):
             )
         elif isinstance(data, VectorData):
             layer = VectorLayer(
-                name, self._remote, data=data, **kwargs
+                name, self._remote, self.layers, data=data, **kwargs
             )
         else:
             assert name is not None, \

--- a/geonotebook/layers.py
+++ b/geonotebook/layers.py
@@ -197,6 +197,7 @@ class VectorLayer(GeonotebookLayer):
             kwargs['colors'] = discrete_colors(kwargs['colormap'], len(data))
 
         name = name or data.reader.name
+        data.layer = self
         super(VectorLayer, self).__init__(name, remote, data, **kwargs)
         self.data = data
 

--- a/geonotebook/layers.py
+++ b/geonotebook/layers.py
@@ -184,7 +184,20 @@ class VectorLayer(GeonotebookLayer):
     StyleOptions = VectorStyleOptions
 
     def __init__(self, name, remote, layer_collection, data, **kwargs):
+        # Here we are storing a reference to the layer collection itself.
+        # This is done to maintain API compatibility between annotation objects
+        # and vector data objects.  For example, to subset all layers from a
+        # given geometry, you could use code such as the following:
+        #
+        #  for layer, data in polygon.data:
+        #    # data a numpy array of the data from "layer"
+        #
+        # In this case, the vector object must contain a reference to the
+        # map layer collection.  In a future refactor, we want to change
+        # this behavior to make passing the layer collection here unnecessary.
+        # New layer types should avoid using this pattern if possible.
         self.layer_collection = layer_collection
+
         # handle styling options in order of precendence
         colors = kwargs.get('colors')
         if isinstance(colors, (list, tuple)):  # a list of colors to use

--- a/geonotebook/layers.py
+++ b/geonotebook/layers.py
@@ -183,7 +183,8 @@ class VectorLayer(GeonotebookLayer):
 
     StyleOptions = VectorStyleOptions
 
-    def __init__(self, name, remote, data, **kwargs):
+    def __init__(self, name, remote, layer_collection, data, **kwargs):
+        self.layer_collection = layer_collection
         # handle styling options in order of precendence
         colors = kwargs.get('colors')
         if isinstance(colors, (list, tuple)):  # a list of colors to use

--- a/geonotebook/wrappers/vector.py
+++ b/geonotebook/wrappers/vector.py
@@ -3,6 +3,8 @@ import collections
 import fiona
 import six
 
+from .. import annotations
+
 
 class VectorData(collections.Sequence):
 
@@ -35,3 +37,35 @@ class VectorData(collections.Sequence):
             'type': 'FeatureCollection',
             'features': features
         }
+
+    @property
+    def points(self):
+        """Return a generator of "Point" annotation objects."""
+        for feature in self.reader:
+            geometry = feature['geometry']
+            if geometry['type'] == 'Point':
+                coords = geometry['coordinates']
+                yield annotations.Point(
+                    coords, **feature['properties']
+                )
+            elif geometry['type'] == 'MultiPoint':
+                for coords in geometry['coordinates']:
+                    yield annotations.Point(
+                        coords, **feature['properties']
+                    )
+
+    @property
+    def polygons(self):
+        """Return a generator of "Polygon" annotation objects."""
+        for feature in self.reader:
+            geometry = feature['geometry']
+            if geometry['type'] == 'Polygon':
+                coords = geometry['coordinates']
+                yield annotations.Polygon(
+                    coords[0], coords[1:], **feature['properties']
+                )
+            elif geometry['type'] == 'MultiPolygon':
+                for coords in geometry['coordinates']:
+                    yield annotations.Polygon(
+                        coords[0], coords[1:], **feature['properties']
+                    )

--- a/geonotebook/wrappers/vector.py
+++ b/geonotebook/wrappers/vector.py
@@ -9,6 +9,9 @@ from .. import annotations
 class VectorData(collections.Sequence):
 
     def __init__(self, path, **kwargs):
+        # the layer attribute will be set once this instance is
+        # added to a layer
+        self.layer = None
         if isinstance(path, six.string_types):
             self.reader = fiona.open(path)
         else:
@@ -46,12 +49,12 @@ class VectorData(collections.Sequence):
             if geometry['type'] == 'Point':
                 coords = geometry['coordinates']
                 yield annotations.Point(
-                    coords, **feature['properties']
+                    coords, layer=self.layer, **feature['properties']
                 )
             elif geometry['type'] == 'MultiPoint':
                 for coords in geometry['coordinates']:
                     yield annotations.Point(
-                        coords, **feature['properties']
+                        coords, layer=self.layer, **feature['properties']
                     )
 
     @property
@@ -62,10 +65,12 @@ class VectorData(collections.Sequence):
             if geometry['type'] == 'Polygon':
                 coords = geometry['coordinates']
                 yield annotations.Polygon(
-                    coords[0], coords[1:], **feature['properties']
+                    coords[0], coords[1:],
+                    layer=self.layer, **feature['properties']
                 )
             elif geometry['type'] == 'MultiPolygon':
                 for coords in geometry['coordinates']:
                     yield annotations.Polygon(
-                        coords[0], coords[1:], **feature['properties']
+                        coords[0], coords[1:],
+                        layer=self.layer, **feature['properties']
                     )

--- a/tests/integration/Layer subsetting.ipynb
+++ b/tests/integration/Layer subsetting.ipynb
@@ -11,7 +11,7 @@
     "%matplotlib inline\n",
     "from matplotlib import pylab as plt\n",
     "from matplotlib.colors import LinearSegmentedColormap\n",
-    "from geonotebook.wrappers import RasterData\n",
+    "from geonotebook.wrappers import RasterData, VectorData\n",
     "import numpy as np\n",
     "from IPython.display import display, Image"
    ]
@@ -120,7 +120,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -159,13 +160,45 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Subsetting vector data"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "M.set_center(-119.63, 47.686, 8)\n",
+    "\n",
+    "M.layers.annotation.clear_annotations()\n",
+    "for l in M.layers:\n",
+    "    M.remove_layer(l)\n",
+    "    \n",
+    "rd = RasterData('data/WELD.tif')\n",
+    "M.add_layer(rd[1, 2, 3])\n",
+    "\n",
+    "v = VectorData('data/wa_county')\n",
+    "M.add_layer(v)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "county = v.polygons.next()\n",
+    "_, data = county.data.next()\n",
+    "plt.imshow(data)"
+   ]
   }
  ],
  "metadata": {

--- a/tests/integration/get_test_data.sh
+++ b/tests/integration/get_test_data.sh
@@ -22,6 +22,10 @@ download 'https://data.kitware.com/api/v1/item/589b390c8d777f07219fcb3e/download
 unzip -o -d "$dir/data/states_20m" $TMPFILE
 rm $TMPFILE
 
+download 'https://data.kitware.com/api/v1/file/58b96a8a8d777f0aef5d0f8c/download'
+unzip -o -d "$dir/data/wa_county" $TMPFILE
+rm $TMPFILE
+
 # geojson
 download 'https://data.kitware.com/api/v1/item/589b624d8d777f07219fcc60/download'
 mv $TMPFILE "$dir/data/ne_50m_populated_places_simple.geojson"


### PR DESCRIPTION
This provides a minimal implementation for subsetting layers from vector data objects.  In addition to the layer containing a layer collection problem, I noticed a few other issues that limit the usefulness of this code.  I can either address them here or in a future PR:

* Derive vector data objects from geopandas data frames or add first class support for generating vector data objects from them.  This will support the common use case of "subset the data from a given polygon in a shapefile".
* Handle "multi geometries" (MultiPoint, MultiPolygon) correctly as a single feature.  Currently, this code generates multiple features from these geometry types.  This makes it difficult to do something like subset from Hawaii.  I did some initial refactoring in [vector-dataset-refactor](https://github.com/OpenGeoscience/geonotebook/tree/vector-dataset-refactor) to support multi geometries uniformly in both vector and annotation objects, but it isn't complete.
* Handle reprojecting vector geometries.  This could be viewed as a bug in the vector data support because many shapefiles in particular are not given in `epsg:4326`.  I made an initial attempt at fixing this here, but decided it would be easier to do within geopandas.
* Support subsetting from lines.  This would go with adding line annotations and is fairly low priority.