### PR TITLE
Add sed to the docker container for build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN set -ex \
          cython \
          python2-futures \
          gdal \
-         mapnik
+         mapnik \
+         sed
 
 
 RUN set -ex \


### PR DESCRIPTION
Building the docker image was failing because sed doesn't exist in the base image.