### PR TITLE
Fixing minor issues with Python 3 compatability

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,7 @@ test:
   pre:
     - mkdir -p $CIRCLE_TEST_REPORTS/{eslint,pytest}
     - mkdir -p $CIRCLE_ARTIFACTS/coverage
+    - pip install -r prerequirements.txt
   override:
     - tox --result-json $CIRCLE_ARTIFACTS/tox-result.json -- --cov-report html:$CIRCLE_ARTIFACTS/coverage --cov-report xml:$CIRCLE_ARTIFACTS/coverage.xml --junitxml=$CIRCLE_TEST_REPORTS/pytest/JUnit.xml
     - npm run --silent --prefix js lint:ci > $CIRCLE_TEST_REPORTS/eslint/JUnit.xml

--- a/geonotebook/kernel.py
+++ b/geonotebook/kernel.py
@@ -230,7 +230,7 @@ class Geonotebook(object):
                     predicate=lambda x: ismethod(x) or isfunction(x)
                 ) if fn in cls.msg_types}
 
-        return cls._protocol.values()
+        return list(cls._protocol.values())
 
     def _send_msg(self, msg):
         """Send a message to the client.
@@ -509,6 +509,7 @@ class GeonotebookKernel(IPythonKernel):
         self.geonotebook._remote = Remote(self.comm.send, self._unwrap(msg))
         # Reply to the open comm,  this should probably be set up on
         # self.geonotebook._remote as an actual proceedure call
+
         self.comm.send({
             "method": "set_protocol",
             "data": self.geonotebook.get_protocol()

--- a/geonotebook/vis/ktile/handler.py
+++ b/geonotebook/vis/ktile/handler.py
@@ -42,8 +42,12 @@ class KtileHandler(IPythonHandler):
         try:
             if self.request.headers["Content-Type"].lower().startswith(
                     "application/json"):
-                self.request.json = json.loads(
-                    self.request.body.encode('utf-8'))
+                try:
+                    body = self.request.body.decode('utf-8')
+                except AttributeError:
+                    body = self.request.body
+
+                self.request.json = json.loads(body)
 
         except Exception:
             self.request.json = None
@@ -84,8 +88,13 @@ class KtileLayerHandler(IPythonHandler):
         try:
             if self.request.headers["Content-Type"].lower().startswith(
                     "application/json"):
-                self.request.json = json.loads(
-                    self.request.body.encode('utf-8'))
+
+                try:
+                    body = self.request.body.decode('utf-8')
+                except AttributeError:
+                    body = self.request.body
+
+                self.request.json = json.loads(body)
         except Exception:
             self.request.json = None
 

--- a/geonotebook/vis/ktile/ktile.py
+++ b/geonotebook/vis/ktile/ktile.py
@@ -59,7 +59,12 @@ class KtileConfigManager(MutableMapping):
         if layer_name not in self._configs[kernel_id].layers:
             self._configs[kernel_id].layers[layer_name] = layer
 
-        return layer.provider.generate_vrt()
+        try:
+            layer.provider.generate_vrt()
+        except AttributeError:
+            pass
+
+        return True
 
 
 # Ktile vis_server,  this is not a persistent object

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,4 @@ ipykernel==4.5.2
 matplotlib
 pyproj
 pandas
-mapnik
 lxml

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from distutils import log
 import glob
 import json
@@ -13,6 +15,25 @@ from setuptools.command.develop import develop
 from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install
 from setuptools.command.sdist import sdist
+
+
+PY3 = (sys.version_info[0] >= 3)
+
+if PY3:
+    try:
+        import mapnik # noqa
+    except ImportError:
+        print("""
+
+Python bindings for Mapnik (https://github.com/mapnik/python-mapnik) are
+required to run GeoNotebook. Unfortunately there are no pip install-able
+versions of the bindings for Python 3. The Mapnik bindings will compile
+under Python 3 but they must be compiled and installed from source.
+Please follow the instructions on the mapnik/python-mapnik repository,
+ensuring you can import mapnik before continuing to install GeoNotebook
+using Python 3.
+        """)
+        sys.exit(1)
 
 
 def post_install(func, **kwargs):
@@ -252,6 +273,7 @@ setup(
         "jupyter_client",
         "notebook",
         "fiona",
+        "mapnik",
         "shapely"
     ],
     cmdclass={

--- a/tests/integration/Layer subsetting.ipynb
+++ b/tests/integration/Layer subsetting.ipynb
@@ -195,8 +195,8 @@
    },
    "outputs": [],
    "source": [
-    "county = v.polygons.next()\n",
-    "_, data = county.data.next()\n",
+    "county = next(v.polygons)\n",
+    "_, data = next(county.data)\n",
     "plt.imshow(data)"
    ]
   }


### PR DESCRIPTION
This returns python 3 comparability to the code base.  Unfortunately there is no pip install-able version of the mapnik bindings and so these have to be installed from source by the user. This is also keeping us from re-introducing the py35 tox environment. 