### PR TITLE
Fix annotation projections

### DIFF
--- a/geonotebook/utils.py
+++ b/geonotebook/utils.py
@@ -1,7 +1,7 @@
 import os
 
 import ipykernel
-
+from rasterio.warp import transform
 
 # Note:  There isn't a better way to do this? Maybe checking kernel against
 # keys/values in kernel_manager class?
@@ -13,3 +13,7 @@ def get_kernel_id(kernel):
     connection_file_path = ipykernel.get_connection_file()
     connection_file = os.path.basename(connection_file_path)
     return connection_file.split('-', 1)[1].split('.')[0]
+
+
+def transform_coordinates(source_srs, target_srs, x, y):
+    return tuple(i[0] for i in transform(source_srs, target_srs, x, y))

--- a/geonotebook/wrappers/raster.py
+++ b/geonotebook/wrappers/raster.py
@@ -158,6 +158,10 @@ class RasterData(collections.Sequence):
             (ulx, uly)])
 
     @property
+    def crs(self):
+        return self.reader.crs
+
+    @property
     def count(self):
         return self.reader.count
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 
 import numpy as np
 import pytest
+from rasterio.crs import CRS
 
 from geonotebook import layers
 from geonotebook.wrappers import RasterData, RasterDataCollection
@@ -39,6 +40,10 @@ class MockReader(object):
     def bounds(self):
         lat, lon = self.bands[0].shape
         return (0, 0, lat, lon)
+
+    @property
+    def crs(self):
+        return CRS.from_string("EPSG:4326")
 
     def get_band_ix(self, indexes, x, y):
         return list(self.get_band_data(i)[y, x]

--- a/tests/integration/Layer subseting (non-wgs84 image).ipynb
+++ b/tests/integration/Layer subseting (non-wgs84 image).ipynb
@@ -1,0 +1,196 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "from matplotlib import pylab as plt\n",
+    "from matplotlib.colors import LinearSegmentedColormap\n",
+    "from geonotebook.wrappers import RasterData, VectorData\n",
+    "import numpy as np\n",
+    "from IPython.display import display, Image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Subsetting points"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EXPECTED=\"https://data.kitware.com/api/v1/item/5970fa4c8d777f16d01e9c64/download\"\n",
+    "# Set the center of the map to the location the data\n",
+    "M.set_center(-114.32, 42.54, 10)\n",
+    "\n",
+    "# Clean up any layers that might already exist\n",
+    "M.layers.annotation.clear_annotations()\n",
+    "for l in M.layers:\n",
+    "    M.remove_layer(l)\n",
+    "\n",
+    "rd = RasterData('data/2016-07-13_ndvi.tif')\n",
+    "\n",
+    "M.add_layer(rd)\n",
+    "M.add_annotation('point', [-114.32, 42.54])\n",
+    "\n",
+    "display(Image(EXPECTED, format=\"png\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "layer, data = next(M.layers.annotation.points[0].data)\n",
+    "assert layer == M.layers[0]\n",
+    "assert all(np.isclose(data, [0.0629543], atol=10e-4))\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Subsetting rectangles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EXPECTED=\"https://data.kitware.com/api/v1/item/5970fa4c8d777f16d01e9c6a/download\"\n",
+    "# Set the center of the map to the location the data\n",
+    "M.set_center(-114.32, 42.55, 13)\n",
+    "\n",
+    "# Clean up any layers that might already exist\n",
+    "M.layers.annotation.clear_annotations()\n",
+    "for l in M.layers:\n",
+    "    M.remove_layer(l)\n",
+    "\n",
+    "rd = RasterData('data/2016-07-13_ndvi.tif')\n",
+    "\n",
+    "M.add_layer(rd)\n",
+    "M.add_annotation('rectangle', [[-114.354, 42.552],\n",
+    "                               [-114.289, 42.552],\n",
+    "                               [-114.289, 42.592],\n",
+    "                               [-114.354, 42.592]])\n",
+    "\n",
+    "display(Image(EXPECTED, format=\"png\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "layer, data = next(M.layers.annotation.rectangles[0].data)\n",
+    "assert layer == M.layers[0]\n",
+    "assert data.shape == (922, 1039)\n",
+    "assert all(np.isclose(data[0, 0], [-0.0276489], atol=10e-4))\n",
+    "plt.imshow(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### Subsetting polygons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "EXPECTED=\"https://data.kitware.com/api/v1/item/5970fa4c8d777f16d01e9c67/download\"\n",
+    "# Set the center of the map to the location the data\n",
+    "M.set_center(-114.32, 42.55, 13)\n",
+    "\n",
+    "# Clean up any layers that might already exist\n",
+    "M.layers.annotation.clear_annotations()\n",
+    "for l in M.layers:\n",
+    "    M.remove_layer(l)\n",
+    "\n",
+    "rd = RasterData('data/2016-07-13_ndvi.tif')\n",
+    "\n",
+    "M.add_layer(rd)\n",
+    "M.add_annotation('polygon', [\n",
+    "    [-114.32888031005858, 42.557379595507584], [-114.30913925170897, 42.557758931865564],\n",
+    "    [-114.28218841552733, 42.57356256365908], [-114.30192947387694, 42.58658174759232],\n",
+    "    [-114.31257247924805, 42.57646999580827], [-114.33677673339842, 42.582031662229916],\n",
+    "    [-114.34038162231444, 42.572930495255626], [-114.32888031005858, 42.557379595507584]\n",
+    "])\n",
+    "\n",
+    "display(Image(EXPECTED, format=\"png\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "layer, data = next(M.layers.annotation.polygons[0].data)\n",
+    "assert layer == M.layers[0]\n",
+    "assert data.shape == (679, 935)\n",
+    "assert all(np.isclose(data[300, 300], [0.0263813], atol=10e-4))\n",
+    "plt.imshow(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Geonotebook (Python 2)",
+   "language": "python",
+   "name": "geonotebook2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
When getting a subset using an annotation, if the source tiff is not in WGS we were getting an empty array. This adds a utility function to transform coordinates of the annotation to the source image's coordinates. Fixes #129 