### PR TITLE
Add gl-mat3 to package.json for latest version of geojs

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -37,6 +37,7 @@
     "expose-loader": "^0.7.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "geojs": "^0.12.2",
+    "gl-mat3": "^1.0.0",
     "gl-mat4": "^1.1.4",
     "gl-vec2": "^1.0.0",
     "gl-vec3": "^1.0.3",


### PR DESCRIPTION
Fixes #140 

@dementiev Thanks for reporting.  There was a compatibility problem with the latest release of geojs.  Could you try rebuilding the docker image from this branch to see if it fixes your problem?
