### PR TITLE
Allow Ktile vis server to work when Jupyter notebook is run on arbitrary port

### DIFF
--- a/config/geonotebook.ini
+++ b/config/geonotebook.ini
@@ -8,7 +8,6 @@ password = geoserver
 url = http://127.0.0.1:8080/geoserver
 
 [ktile]
-url = http://127.0.0.1:8888/ktile
 default_cache = ktile_default_cache
 
 [ktile_default_cache]

--- a/geonotebook/__init__.py
+++ b/geonotebook/__init__.py
@@ -5,7 +5,6 @@ import pkg_resources
 
 from .config import Config
 
-
 def _jupyter_server_extension_paths():
     return [{
         "module": "geonotebook"
@@ -66,7 +65,7 @@ def load_jupyter_server_extension(nbapp):
     webapp = nbapp.web_app
     conf = Config()
 
-    conf.vis_server.initialize_webapp(conf, webapp)
+    conf.vis_server.initialize_webapp(conf, webapp, log=nbapp.log, port=nbapp.port)
 
     base_url = webapp.settings['base_url']
 

--- a/geonotebook/__init__.py
+++ b/geonotebook/__init__.py
@@ -65,7 +65,7 @@ def load_jupyter_server_extension(nbapp):
     webapp = nbapp.web_app
     conf = Config()
 
-    conf.vis_server.initialize_webapp(conf, webapp, log=nbapp.log, port=nbapp.port)
+    conf.vis_server.initialize_webapp(conf, nbapp)
 
     base_url = webapp.settings['base_url']
 

--- a/geonotebook/vis/comm_protocol.py
+++ b/geonotebook/vis/comm_protocol.py
@@ -1,0 +1,86 @@
+import pickle
+import zmq
+import tempfile
+import os
+
+def webapp_comm_send(msg):
+    ctx = zmq.Context()
+    s = ctx.socket(zmq.REQ)
+
+    with open("{}/{}".format(tempfile.gettempdir(), os.environ['USER']), 'r') as f:
+        comm_port = int(f.read())
+
+    s.connect("tcp://127.0.0.1:{}".format(comm_port))
+    s.send(pickle.dumps(msg))
+    resp = pickle.loads(s.recv())
+    s.close()
+    return resp
+
+def make_callback(transport, protocol):
+    def _recv(msg):
+        result = protocol(msg)
+        protocol.nbapp.log.info("Sending response: {}".format(result))
+        transport.send(pickle.dumps(result))
+
+    return _recv
+        
+class WebAppProtocol(object):
+    def __init__(self, nbapp):
+        self.nbapp = nbapp
+
+    def __call__(self, msg):
+        data = pickle.loads(msg[0])
+        self.nbapp.log.info("ZMQ socket received data={}".format(data))
+        action =  data.get('action', 'err_missing_action')
+        try:
+            return getattr(self, action)(**data)        
+        except Exception as e:
+            return {
+                'success': False,
+                'err_msg': 'Unidentified protocol error: {}'.format(str(e))
+            }
+                               
+    def register_kernel(self, **data):
+        kernel_id = data['kernel_id']
+        kwargs = {} if 'json' not in data else data['json']
+        try:
+            self.nbapp.web_app.ktile_config_manager.add_config(kernel_id, **kwargs)
+            return { 'success': True }
+        except Exception as exc:
+            return { 'success': False,
+                     'err_msg': exc
+            }
+
+    def delete_kernel(self, **data):
+        kernel_id = data['kernel_id']
+        try:
+            del self.nbapp.web_app.ktile_config_manager[kernel_id]
+            return { 'success': True }
+        except KeyError:
+            return { 'success': False,
+                     'err_msg': u'Kernel %s not found' % kernel_id
+            }
+
+    def add_layer(self, **data):
+        try:
+            kernel_id = data['kernel_id']
+            layer_name = data['layer_name']
+            self.nbapp.web_app.ktile_config_manager.add_layer(kernel_id, layer_name, data['json'])
+            return { 'success': True }
+        except Exception:
+            import sys
+            import traceback
+            t, v, tb = sys.exc_info()
+            return { 'success': False,
+                     'err_msg': traceback.format_exception(t, v, tb)
+            }
+
+    def request_port(self, **data):
+        return { 'port': self.nbapp.port }
+            
+            
+    def err_missing_action(self, **data):
+        return {
+            'success': False,
+            'err_msg': 'Unrecognized request, no action'
+        }

--- a/geonotebook/vis/comm_protocol.py
+++ b/geonotebook/vis/comm_protocol.py
@@ -77,7 +77,9 @@ class WebAppProtocol(object):
 
     def request_port(self, **data):
         return { 'port': self.nbapp.port }
-            
+
+    def request_base_url(self, **data):
+        return { 'base_url': self.nbapp.web_app.settings['base_url'] }
             
     def err_missing_action(self, **data):
         return {

--- a/geonotebook/vis/ktile/handler.py
+++ b/geonotebook/vis/ktile/handler.py
@@ -99,6 +99,8 @@ class KtileLayerHandler(IPythonHandler):
             self.request.json = None
 
     def post(self, kernel_id, layer_name):
+        self.ktile_config_manager.log.info("Installing layer {}".format(layer_name))
+
         # Note: needs paramater validation
         try:
             self.ktile_config_manager.add_layer(
@@ -118,6 +120,8 @@ class KtileLayerHandler(IPythonHandler):
             self.finish({'error': traceback.format_exception(t, v, tb)})
 
     def get(self, kernel_id, layer_name, **kwargs):
+        self.ktile_config_manager.log.info("Requesting layer {}".format(layer_name))
+
         try:
             config = self.ktile_config_manager[kernel_id]
         except KeyError:
@@ -140,6 +144,8 @@ class KtileTileHandler(IPythonHandler):
     @gen.coroutine
     def get(self, kernel_id, layer_name, x, y, z, extension, **kwargs):
 
+        self.ktile_config_manager.log.info("Requesting {}/{}/{} from {}".format(z, x, y, layer_name))
+        
         config = self.ktile_config_manager[kernel_id]
 
         layer = config.layers[layer_name]

--- a/geonotebook/vis/ktile/ktile.py
+++ b/geonotebook/vis/ktile/ktile.py
@@ -126,6 +126,7 @@ class Ktile(object):
         port = nbapp.port
 
         base_url = webapp.settings['base_url']
+        log.info("Initializing web app with base url '{}'".format(base_url))
 
         webapp.ktile_config_manager = KtileConfigManager(
             self.default_cache,
@@ -135,7 +136,7 @@ class Ktile(object):
         io_loop = IOLoop.current()
         ctx = zmq.Context()
         socket = ctx.socket(zmq.REP)
-        selected_port = socket.bind_to_random_port("tcp://*", min_port=49152, max_port=65535, max_tries=100)
+        selected_port = socket.bind_to_random_port("tcp://127.0.0.1", min_port=49152, max_port=65535, max_tries=100)
 
         user = os.environ['USER']
         log.info("Webapp communication channel opened on port {} for user {}".format(selected_port, user))
@@ -243,8 +244,11 @@ class Ktile(object):
             options.update(self._dynamic_vrt_options(data, kwargs))
 
         # Make the Request
-        port_request = webapp_comm_send({ 'action': 'request_port' })
-        base_url = 'http://127.0.0.1:{}/ktile/{}/{}'.format(port_request['port'], kernel_id, name)
+        # port_request = webapp_comm_send({ 'action': 'request_port' })
+        # base_url = 'http://127.0.0.1:{}/ktile/{}/{}'.format(port_request['port'], kernel_id, name)
+
+        base_url_query = webapp_comm_send({ 'action': 'request_base_url' })
+        base_url = '{}ktile/{}/{}'.format(base_url_query['base_url'], kernel_id, name)
 
         resp = webapp_comm_send({
             'action': 'add_layer',

--- a/geonotebook/vis/ktile/ktile.py
+++ b/geonotebook/vis/ktile/ktile.py
@@ -86,7 +86,7 @@ class KtileConfigManager(MutableMapping):
 # different contexts!
 
 class Ktile(object):
-    def __init__(self, config, default_cache=None):
+    def __init__(self, config, default_cache=None, **kwargs):
         self.config = config
         self.default_cache_section = default_cache
 

--- a/geonotebook/vis/ktile/ktile.py
+++ b/geonotebook/vis/ktile/ktile.py
@@ -84,9 +84,8 @@ class KtileConfigManager(MutableMapping):
 # different contexts!
 
 class Ktile(object):
-    def __init__(self, config, url=None, default_cache=None):
+    def __init__(self, config, default_cache=None):
         self.config = config
-        self.base_url = url
         self.default_cache_section = default_cache
 
     @property
@@ -114,9 +113,6 @@ class Ktile(object):
         else:
             raise RuntimeError("Unknown error during kernel registration" if 'err_msg' not in resp else resp['err_msg'])
 
-        # requests.post("{}/{}".format(self.base_url, kernel_id))
-        # Error checking on response!
-
     def shutdown_kernel(self, kernel):
         kernel_id = get_kernel_id(kernel)
         resp = self.webapp_comm({
@@ -129,9 +125,7 @@ class Ktile(object):
         else:
             raise RuntimeError("Unknown error during kernel delete" if 'err_msg' not in resp else resp['err_msg'])
 
-        #requests.delete("{}/{}".format(self.base_url, kernel_id))
-
-    # This function is caleld inside the tornado web app
+    # This function is called inside the tornado web app
     # from jupyter_load_server_extensions
     def initialize_webapp(self, config, webapp, log=None, port=None):
         base_url = webapp.settings['base_url']
@@ -315,19 +309,3 @@ class Ktile(object):
             raise RuntimeError("KTile.ingest() failed with error:\n\n{}".format(resp['err_msg']))
 
         return base_url
-
-        # r = requests.post(base_url, json={
-        #     "provider": {
-        #         "class": "geonotebook.vis.ktile.provider:MapnikPythonProvider",
-        #         "kwargs": options
-        #     }
-        #     # NB: Other KTile layer options could go here
-        #     #     See: http://tilestache.org/doc/#layers
-        # })
-
-        # if r.status_code == 200:
-        #     return base_url
-        # else:
-        #     raise RuntimeError(
-        #         "KTile.ingest() returned {} error:\n\n{}".format(
-        #             r.status_code, ''.join(r.json()['error'])))


### PR DESCRIPTION
Previously, it was required to specify a `url` in the `[ktile]` section of the geonotebook.ini file, which essentially set the port number that the Ktile vis server would look for the Jupyter notebook instance on. This meant that notebook instances launched with a `--port` that did not match that in the `url` would fail to display layer data.  This affected any notebook instance launched from JupyterHub.

To determine the port on which the Tornado webapp was running, I used of a ZeroMQ socket plugged into the Tornado event loop. Now, it is possible to make queries on port 14253 to determine the port number of the running process.

Along the way, I used this 0MQ system to eliminate the use of Python's requests library in the ktile server. This ought to allow for a simplified handler structure in the webapp, and should remove a layer of indirection.

On the downside, this mod won't allow multiple users on the same system to run concurrently due to contention for the port that 0MQ is listening on.