### PR TITLE
Fix annotations support on non-webgl browsers

### DIFF
--- a/js/config/resolve.js
+++ b/js/config/resolve.js
@@ -1,6 +1,6 @@
 var path = require('path');
 
-var renderer = process.env.GEONOTEBOOK_MAP_RENDERER || 'geojs';
+var renderer = process.env.GEONOTEBOOK_MAP_RENDERER || 'ol';
 
 module.exports = {
   alias: {


### PR DESCRIPTION
The annotation features used by Geonotebook are only supported by geojs's webgl renderer.  It is not uncommon for webgl to be broken on some systems and is often difficult to diagnose and fix.  To support fallback to canvas for users pulling from docker hub, this switches the default map renderer to openlayers.