### PR TITLE
Pin dependencies to compatible versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,9 +63,8 @@ ADD ./devops/docker/jupyter.sh /jupyter.sh
 
 WORKDIR /opt/geonotebook
 
-RUN .  /root/.bashrc && pip2.7 install -r prerequirements.txt && \
-    pip2.7 install -U -r requirements.txt && \
-    pip2.7 install . && \
+RUN .  /root/.bashrc && pip2.7 install -U -r prerequirements.txt && \
+    pip2.7 install -U -r requirements.txt . && \
     jupyter serverextension enable --py geonotebook --sys-prefix && \
     jupyter nbextension enable --py geonotebook --sys-prefix
 

--- a/devops/docker/jupyter.sh
+++ b/devops/docker/jupyter.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-jupyter-notebook --no-browser --ip='0.0.0.0' --allow-root "$@"
+jupyter-notebook --no-browser --ip='0.0.0.0' "$@"

--- a/prerequirements.txt
+++ b/prerequirements.txt
@@ -1,5 +1,5 @@
 numpy==1.11.1
 jupyter-client==4.4.0
 ipykernel==4.5.2
-notebook==4.3.1
+notebook<5
 https://github.com/OpenGeoscience/KTile/archive/master.zip

--- a/setup.py
+++ b/setup.py
@@ -274,7 +274,8 @@ setup(
         "notebook",
         "fiona",
         "mapnik",
-        "shapely"
+        "shapely",
+        "tornado<5.0"
     ],
     cmdclass={
         'install': CustomInstall,


### PR DESCRIPTION
Several dependencies have released backwards incompatible changes that we need to blacklist locally.  I think these would be easy to fix, but until we have time to fix them, this at least restores working docker builds.