### PR TITLE
Use get_transform function to get geotransform from rasterio.

### DIFF
--- a/geonotebook/vis/ktile/ktile.py
+++ b/geonotebook/vis/ktile/ktile.py
@@ -150,7 +150,7 @@ class Ktile(object):
             # TODO:  Needs to be moved into RasterData level API
             'raster_x_size': data.reader.width,
             'raster_y_size': data.reader.height,
-            'transform': data.reader.dataset.profile['transform'],
+            'transform': data.reader.dataset.get_transform(),
             'dtype': data.reader.dataset.profile['dtype']
         }
         if 'map_srs' in kwargs:


### PR DESCRIPTION
Compatible with 0.36 and 1.0.x

Should fix https://github.com/OpenGeoscience/geonotebook/issues/139